### PR TITLE
Add ruby 2.7 to Travis CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,10 @@ env:
     - secure: "pdtydri6wzvAidSbT0VzAsQmzkm97I6WGMtO+eAL1Sxg5WYQ3qTiq/yNSzZNZiSz/fxOurCjbtbGulzS/ycal11XAEFq+A5S5d5anfi9YTMx+e4xQI39kMoiHvwGrMzU2EndKW3TX7NQ3/IZ/wkuLgImM2I2C2N1EPFxvcPbGPPF9sb9EM6dY5aEWhtkF5Y1I0/eC/WOtIpG5pc/JBYbb9D9YLlF0CeYVPKxrLdNI9RdsR4ihpD5PwGWHEOZkswkTYtp/xyAIhOMBJNlcDYFll0v0DzgnGiU7XXSMGb9XS6NlHTRQURjVIiyzxyFAcAYIeItTUOPhoPsTuD+mxOVCny6bv/4UlO9fTNTpPWLd6dpD/vrLkAz2fR73ImRms3LSwIoFbQzRsAtFEwipxPEJRLQODFoBmJgg2bkNBRGkXmgP9Ys0bVdIQhdqzJOtKdktVUxCfhV0x58hWM9oCbw/wYit3bapP8QmPxVyulkK+RWVSj9CIFyfL333uau0DGMofGxU7OBgwEhw5a87VDyg5s7I2KbeXLJ4LWXrYzTwz9tgvAo+90aOgyMYokSEIxMZ2lxob2qHrIz/xqPEUONssmLOXehwt43durBn/9sX6Dis2QfpeMcHkA+QnUSuBwqNgkobizR/8uzDhG61kBFIKriv3KBqSckaX+T7YGtlK8="
     - secure: "FgxC/oxddf72rc/pf7EzA8UpT6iqYWQUetRvyQPL1eey4XjP0N4bP535IqTUnYpLed2RZmtbSzcm5mjry6Ba/VGliaIA9S/EQKHQHmBKUGhNkqGzhqjHrnwUvXncmbr6N8bqinaq/2WSYZ/XMVBn8m+lESF3pgEiximaieZnO1HYD7RgZJclPET5qqG4jHqpVBCLa67Gz4MdAWRLci8rksTazXOnxA4y/xPZKcIHfaW//IC+dUXWK5egCERAplkh+aJhK0w3vUCv9XAuvzKFeKVljaVuGnZmLuezMwJYqpIJhP4TiAQIb9JR7JZZ1LTH6Iuk8VJsOmyrFG4jMbXkfwWKQ/e1zRoKuNvmjG/V1YU56NONMSqIiAYesv3yrnJDgfPeaye3fUgAaLSRNhGR+4dSPuEsCcfbOHU0s4AArp4Q2hlnvJ0VdnaAZJXj8lfQhLRXOh8wQbjoFLwuwptxfb5k5WBtf6jsfmax4P4v0JIkzVopNkfSwgHJFYx35i44fmtRoZEsdxPMdURpE4GJELTlTViuDkbJYpkbSUYEomQbvCSb7pb1UFsKTz5tpbStt1Qmm4eUwXDnhD9dWnBZgHnFShdj1c9527OE5tOl7yIIueUxQ+xqN5wFF2MaOr9sm2/DMXwkBApGIF9y+u/J7zS8GsX7kpK5hkyU8eE/9dA="
 rvm:
-  - 2.2
-  - 2.3
   - 2.4
   - 2.5
-before_script:
-  - gem update --system
-  - gem update --remote bundler
+  - 2.6
+  - 2.7
 script:
   - bundle exec rspec
   - bundle exec rubocop

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The naming of environment variables is optional and can be customized.
 
 ## Installation
 
-This gem has been tested with ruby version 2.2 to 2.5.
+This gem has been tested with ruby version 2.4 to 2.7.
 
 ```
 gem install aws-ssm-env

--- a/README_ja.md
+++ b/README_ja.md
@@ -13,7 +13,7 @@ AWS EC2 Parameter Storeから取得したパラメータを環境変数として
 
 ## Installation
 
-このgemはRuby2.2から2.5まででテストされています。
+このgemはRuby2.4から2.7まででテストされています。
 
 ```
 gem install aws-ssm-env

--- a/aws-ssm-env.gemspec
+++ b/aws-ssm-env.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files spec`.split($OUTPUT_RECORD_SEPARATOR)
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.2'
+  spec.required_ruby_version = '>= 2.4'
   spec.metadata = {
     'source_code_uri' => 'https://github.com/sonodar/aws-ssm-env-ruby',
     'changelog_uri'   => 'https://github.com/sonodar/aws-ssm-env-ruby/tree/master/CHANGELOG.md'


### PR DESCRIPTION
This PR adds ruby 2.7 and 2.6 to Travis CI test matrix.  It also drops ruby 2.2 and 2.3 from test matrix.
