### PR TITLE
Fix for early abort when next_token is not null

### DIFF
--- a/lib/aws-ssm-env/fetcher.rb
+++ b/lib/aws-ssm-env/fetcher.rb
@@ -36,9 +36,6 @@ module AwsSsmEnv
       loop do
         response = fetch(next_token)
         next_token = response.next_token
-        if response.parameters.empty?
-          break
-        end
         response.parameters.each do |p|
           yield(p)
         end

--- a/spec/aws-ssm-env/fetcher_spec.rb
+++ b/spec/aws-ssm-env/fetcher_spec.rb
@@ -92,15 +92,19 @@ describe AwsSsmEnv::Fetcher do
       mock_class.new(responses)
     }
 
+    def call_count
+      called = 0
+      fetcher.each do |_|
+        called += 1
+      end
+      called
+    end
+
     context 'when fetch returns empty parameters at first' do
       let(:responses) { [AwsSsmEnv::FetchResult::EMPTY] }
 
       it 'consumer is not called' do
-        called = false
-        fetcher.each do |_|
-          called = true
-        end
-        expect(called).to be_falsey
+        expect(call_count).to eq(0)
       end
     end
 
@@ -111,11 +115,7 @@ describe AwsSsmEnv::Fetcher do
       }
 
       it 'consumer is called twice' do
-        called = 0
-        fetcher.each do |_|
-          called += 1
-        end
-        expect(called).to eq(2)
+        expect(call_count).to eq(2)
       end
     end
 
@@ -123,11 +123,7 @@ describe AwsSsmEnv::Fetcher do
       let(:responses) { [AwsSsmEnv::FetchResult.new(parameters, nil)] }
 
       it 'consumer is called twice' do
-        called = 0
-        fetcher.each do |_|
-          called += 1
-        end
-        expect(called).to eq(2)
+        expect(call_count).to eq(2)
       end
     end
 
@@ -138,11 +134,7 @@ describe AwsSsmEnv::Fetcher do
       }
 
       it 'consumer is called four times' do
-        called = 0
-        fetcher.each do |_|
-          called += 1
-        end
-        expect(called).to eq(4)
+        expect(call_count).to eq(4)
       end
     end
   end


### PR DESCRIPTION
Results from the SSM API are returned on a best-effort basis. An API call may return 0 items but still yield a `next_token` key, meaning that the work done API-side yielded no results yet but future calls (searching further through the parameter space) may yield more results.

Previously an empty `response.parameters` would abort parameter fetching, even if `next_token` was not nil. This patch fixes that and adds an rspec example for it like the existing ones.